### PR TITLE
fix: Convert client's local time to UTC for session creation

### DIFF
--- a/src/components/CalendarStrip.jsx
+++ b/src/components/CalendarStrip.jsx
@@ -26,14 +26,16 @@ const CalendarStrip = (props) => {
 
     useEffect(() => {
         if (memoizedRawDate && memoizedRawTime) {
-            const timeout = setTimeout(() => {
-                console.log(`Timeout Run`);
+            const timeout = setTimeout(() => {  
                 setShouldRender(false);
+                const clientDateTime = new Date(`${memoizedRawDate}${memoizedRawTime}`);
+                const utcDateTime = clientDateTime.toISOString();
+               
                 props.actions.scheduleAction({
                     date: selectedDateIndex,
                     time: selectedTimeValue,
                     day: selectedDayOfWeek,
-                    rawRescheduledDateTime: `${memoizedRawDate}${memoizedRawTime}`,
+                    rawRescheduledDateTime: utcDateTime,
                 });
                 props.actions.modeSelection();
                 setSelectedRawDate(undefined);

--- a/src/components/CreateSessionModal.jsx
+++ b/src/components/CreateSessionModal.jsx
@@ -52,10 +52,12 @@ const CreateSessionModal = ({isOpen, onClose, setTabIndex}) => {
 
         const handleCreateSession = async () => {
             const rawSelectedDate = dateRegexFormatter(selectedDate);
+            const clientDateTime = new Date(`${rawSelectedDate}${selectedTime.hours}:${selectedTime.minutes}`);
+            const utcDateTime = clientDateTime.toISOString();
 
             try {
                 await create({
-                    datetime: `${rawSelectedDate}${selectedTime.hours}:${selectedTime.minutes}`,
+                    datetime: utcDateTime,
                     mode: selectedMode,
                 }).unwrap();
                 toast.success("Session Created", {


### PR DESCRIPTION
### **This PR achieves the following:**

- Refactors session creation logic to directly convert the client's selected to UTC time.
- Removes unnecessary splitting and extraction of hours and minutes.
- Verifies time conversion for accuracy and consistency across various time zones.
